### PR TITLE
add object type to support the dynamic object (the native JsonObject typ...

### DIFF
--- a/pomelo-dotnetClient/src/protobuf/MsgDecoder.cs
+++ b/pomelo-dotnetClient/src/protobuf/MsgDecoder.cs
@@ -148,6 +148,8 @@ namespace Pomelo.Protobuf
                     return this.decodeDouble();
                 case "string":
                     return this.decodeString();
+                case "object":
+                    return SimpleJson.SimpleJson.DeserializeObject(this.decodeString());
                 default:
                     return this.decodeObject(type, proto);
             }


### PR DESCRIPTION
...e)

If you want to transmit data like:
**{"1": "200", "2": 202, "3": 302, ..., "n": 1000}**
You cant use protobuf, because that's the unknow "message type", so hardly to definition a "message" type in protos file.
but that's native JsonObject, Why not to support this data format?
so i add the "object" type in to "uInt32,sInt32,int32,double,string,message,float" to support "the dynamic object"(just JsonObject).
just one line~~