### PR TITLE
add "object" type in protobuf to support js dynamic object

### DIFF
--- a/pomelo-dotnetClient/src/protobuf/MsgDecoder.cs
+++ b/pomelo-dotnetClient/src/protobuf/MsgDecoder.cs
@@ -93,12 +93,12 @@ namespace Pomelo.Protobuf
                                             object _name;
                                             if (!msg.TryGetValue(name.ToString(), out _name))
                                             {
-                                                msg.Add(name.ToString(), new List<object>());
+                                                msg.Add(name.ToString(), new JsonArray());
                                             }
                                             object value_type;
                                             if (msg.TryGetValue(name.ToString(), out _name) && ((JsonObject)(value)).TryGetValue("type", out value_type))
                                             {
-                                                decodeArray((List<object>)_name, value_type.ToString(), proto);
+                                                decodeArray((JsonArray)_name, value_type.ToString(), proto);
                                             }
                                             break;
                                     }
@@ -148,6 +148,8 @@ namespace Pomelo.Protobuf
                     return this.decodeDouble();
                 case "string":
                     return this.decodeString();
+                case "object":
+                    return SimpleJson.SimpleJson.DeserializeObject(this.decodeString());
                 default:
                     return this.decodeObject(type, proto);
             }

--- a/pomelo-dotnetClient/src/protobuf/MsgEncoder.cs
+++ b/pomelo-dotnetClient/src/protobuf/MsgEncoder.cs
@@ -146,9 +146,9 @@ namespace Pomelo.Protobuf
                                 object msg_key;
                                 if (msg.TryGetValue(key, out msg_key))
                                 {
-                                    if (((List<object>)msg_key).Count > 0)
+                                    if (((JsonArray)msg_key).Count > 0)
                                     {
-                                        offset = encodeArray((List<object>)msg_key, (JsonObject)value, offset, buffer, proto);
+                                        offset = encodeArray((JsonArray)msg_key, (JsonObject)value, offset, buffer, proto);
                                     }
                                 }
                                 break;
@@ -163,7 +163,7 @@ namespace Pomelo.Protobuf
         /// <summary>
         /// Encode the array type.
         /// </summary>
-        private int encodeArray(List<object> msg, JsonObject value, int offset, byte[] buffer, JsonObject proto)
+        private int encodeArray(JsonArray msg, JsonObject value, int offset, byte[] buffer, JsonObject proto)
         {
             object value_type, value_tag;
             if (value.TryGetValue("type", out value_type) && value.TryGetValue("tag", out value_tag))
@@ -209,6 +209,7 @@ namespace Pomelo.Protobuf
                 case "double":
                     this.writeDouble(buffer, ref offset, value);
                     break;
+                case "object":
                 case "string":
                     this.writeString(buffer, ref offset, value);
                     break;


### PR DESCRIPTION
use "object" type in protobuf you can transmit data like:
{"1": 100, "2": 101, "3": 201, ..., "n": value}